### PR TITLE
Move the shebang to the appropriate place

### DIFF
--- a/usr/local/bin/status/status.sh
+++ b/usr/local/bin/status/status.sh
@@ -1,9 +1,9 @@
+#!/bin/bash
+
 # Shiori Server Status
 # Version 1.1 (2022-03-07)
 # Copyright (c) 2022 Sora Arakawa
 # Licensed under the MIT License
-
-#!/bin/bash
 
 {
 	cat <<-EOS


### PR DESCRIPTION
The shebang must be on the first line of files.
See the following references:
- [Why should the shebang line always be the first line? (StackOverflow)](https://stackoverflow.com/a/12911604)
- [The source code of the shebang parser in Linux (torvalds/linux)](https://github.com/torvalds/linux/blob/5bfc75d92efd494db37f5c4c173d3639d4772966/fs/binfmt_script.c#L40-L42)